### PR TITLE
ffiのバージョンを下げてみる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'devise'
 gem 'faker'
 gem 'hamlit'
 gem 'aws-sdk-s3', require: false
+gem "ffi", "< 1.17.0"
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,8 +120,7 @@ GEM
     erubis (2.7.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.16.3)
     globalid (1.1.0)
       activesupport (>= 5.0)
     haml (6.3.0)
@@ -334,6 +333,7 @@ DEPENDENCIES
   dotenv-rails
   erb2haml
   faker
+  ffi (< 1.17.0)
   hamlit
   jbuilder (~> 2.7)
   listen (~> 3.2)


### PR DESCRIPTION
ffi-1.17.0-x86_64-linux requires rubygems version >= 3.3.22, which is incompatible with the current version, 3.1.6

これを解消するために、ffiのバージョンを下げてみる